### PR TITLE
Change remote thumbnail dir path

### DIFF
--- a/synapse/rest/media/v1/filepath.py
+++ b/synapse/rest/media/v1/filepath.py
@@ -114,7 +114,7 @@ class MediaFilePaths:
         top_level_type, sub_type = content_type.split("/")
         file_name = "%i-%i-%s-%s-%s" % (width, height, top_level_type, sub_type, method)
         return os.path.join(
-            "remote_thumbnail",
+            "remote_thumbnails",
             server_name,
             file_id[0:2],
             file_id[2:4],
@@ -133,7 +133,7 @@ class MediaFilePaths:
         top_level_type, sub_type = content_type.split("/")
         file_name = "%i-%i-%s-%s" % (width, height, top_level_type, sub_type)
         return os.path.join(
-            "remote_thumbnail",
+            "remote_thumbnails",
             server_name,
             file_id[0:2],
             file_id[2:4],
@@ -144,7 +144,7 @@ class MediaFilePaths:
     def remote_media_thumbnail_dir(self, server_name: str, file_id: str) -> str:
         return os.path.join(
             self.base_path,
-            "remote_thumbnail",
+            "remote_thumbnails",
             server_name,
             file_id[0:2],
             file_id[2:4],

--- a/tests/replication/test_multi_media_repo.py
+++ b/tests/replication/test_multi_media_repo.py
@@ -229,7 +229,7 @@ class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
     def _count_remote_thumbnails(self) -> int:
         """Count the number of files in our remote thumbnails directory."""
         path = os.path.join(
-            self.hs.get_media_repository().primary_base_path, "remote_thumbnail"
+            self.hs.get_media_repository().primary_base_path, "remote_thumbnails"
         )
         return sum(len(files) for _, _, files in os.walk(path))
 


### PR DESCRIPTION
Local thumbnail folder path is `local_thumbnails` but remote one is `remote_thumbnail`.
In the Readme, it is described as `remote_thumbnails` also but `remote_thumbnail` in the code. Seems it is a typo.
Need to match naming convention for both. It is helpful for thumbnail code.